### PR TITLE
docs: changing SLIP73 to SLIP-0173

### DIFF
--- a/guides/token-listing.md
+++ b/guides/token-listing.md
@@ -26,7 +26,7 @@ Recommended readings:
 * [IBC Overview](https://docs.cosmos.network/v0.43/ibc/overview.html) - To understand IBC clients, connections, 
 * [How to Upgrade IBC Chains and their Clients](https://docs.cosmos.network/v0.43/ibc/upgrades/quick-guide.html)
 
-### 1. Add your chain to cosmos/chain-registry and SLIP73
+### 1. Add your chain to cosmos/chain-registry and SLIP-0173
 
 #### Cosmos Chain Registry
 Make a PR to add your chain's entry to the [Cosmos Chain Registry](https://github.com/cosmos/chain-registry). This allows Osmosis frontend to suggest your chain for asset deposit/withdrawals(IBC transfers).
@@ -51,8 +51,8 @@ At this time, Osmosis requires that all relayers to pay for the transaction fees
 
 If you prefer not to run your own chain's relayer to Osmosis, there may be various entities ([Cephalopod Equipment Corp.](https://cephalopod.equipment/), [Vitwit](https://www.vitwit.com/), etc) that provide relayers-as-a-service, or you may reach out to various validators in your ecosystem that may be able to operate a relayer. The Osmosis team does **not** provide relayer services for IBC assets.
 
-#### SLIP73 bech32 prefix
-Add your chain's bech32 prefix to the [SLIP73 repo](https://github.com/satoshilabs/slips/blob/master/slip-0173.md). The bech32 prefix should be a unix prefix, and only mainnet prefixes should be included.
+#### SLIP-0173 bech32 prefix
+Add your chain's bech32 prefix to the [SLIP-0173 repo](https://github.com/satoshilabs/slips/blob/master/slip-0173.md). The bech32 prefix should be a unix prefix, and only mainnet prefixes should be included.
 
 
 ### 3. Making a PR to Osmosis/assetlists


### PR DESCRIPTION
Is there a specific reason why it was written as SLIP73 and not the SLIP-0173?